### PR TITLE
fix(ton): normalizar la URL JSON-RPC de Toncenter

### DIFF
--- a/Repositories/TON/modules/ton-api.client.js
+++ b/Repositories/TON/modules/ton-api.client.js
@@ -3,6 +3,11 @@ const config = require("../../../Core/config");
 
 const getBaseUrl = () => (config.ton?.indexerUrl || "https://tonapi.io").replace(/\/$/, "");
 
+const normalizeTonRpcUrl = (value) => {
+	const rpcUrl = (value || "https://toncenter.com/api/v2/jsonRPC").trim().replace(/\/$/, "");
+	return /\/api\/v2$/i.test(rpcUrl) ? `${rpcUrl}/jsonRPC` : rpcUrl;
+};
+
 const getHeaders = () => {
 	const apiKey = config.ton?.apiKey;
 	if (!apiKey) return {};
@@ -20,7 +25,7 @@ const tonApiGet = async (path, params = {}) => {
 };
 
 const tonCenterPost = async (method, params = {}) => {
-	const rpcUrl = (config.ton?.rpcUrl || "https://toncenter.com/api/v2").replace(/\/$/, "");
+	const rpcUrl = normalizeTonRpcUrl(config.ton?.rpcUrl);
 	const body = { id: "1", jsonrpc: "2.0", method, params };
 	const headers = { "Content-Type": "application/json" };
 	if (config.ton?.apiKey) {
@@ -39,6 +44,7 @@ const tonCenterPost = async (method, params = {}) => {
 };
 
 module.exports = {
+	normalizeTonRpcUrl,
 	tonApiGet,
 	tonCenterPost,
 };

--- a/tests/unit/ton-api-client.test.js
+++ b/tests/unit/ton-api-client.test.js
@@ -1,0 +1,21 @@
+const { normalizeTonRpcUrl } = require("../../Repositories/TON/modules/ton-api.client");
+
+describe("TON API client", () => {
+	it("adds the JSON-RPC path when TON_RPC_URL contains the Toncenter API base URL", () => {
+		expect(normalizeTonRpcUrl("https://toncenter.com/api/v2")).toBe(
+			"https://toncenter.com/api/v2/jsonRPC"
+		);
+		expect(normalizeTonRpcUrl("https://testnet.toncenter.com/api/v2/")).toBe(
+			"https://testnet.toncenter.com/api/v2/jsonRPC"
+		);
+	});
+
+	it("preserves complete and provider-specific RPC URLs", () => {
+		expect(normalizeTonRpcUrl("https://toncenter.com/api/v2/jsonRPC")).toBe(
+			"https://toncenter.com/api/v2/jsonRPC"
+		);
+		expect(normalizeTonRpcUrl("https://rpc.example.com/custom-path/")).toBe(
+			"https://rpc.example.com/custom-path"
+		);
+	});
+});


### PR DESCRIPTION
## Resumen

- Completa automáticamente /jsonRPC cuando TON_RPC_URL contiene la base /api/v2 de Toncenter.
- Conserva sin cambios las URLs completas y las de proveedores personalizados.
- Corrige el error del envío TON reportado en Open-Verifik/zelf-android-online#448.

## Validación

- 2 pruebas unitarias aprobadas.
- Consulta real getWalletInformation contra Toncenter aprobada sin requerir una API key.