### PR TITLE
fix(ton): enviar el mensaje externo completo a Toncenter

### DIFF
--- a/Repositories/TON/modules/ton-api.client.js
+++ b/Repositories/TON/modules/ton-api.client.js
@@ -31,10 +31,23 @@ const tonCenterPost = async (method, params = {}) => {
 	if (config.ton?.apiKey) {
 		headers["X-API-Key"] = config.ton.apiKey;
 	}
-	const { data } = await axios.post(rpcUrl, body, {
-		headers,
-		timeout: config.ton?.timeoutMs || 30000,
-	});
+	let data;
+	try {
+		({ data } = await axios.post(rpcUrl, body, {
+			headers,
+			timeout: config.ton?.timeoutMs || 30000,
+		}));
+	} catch (error) {
+		const upstreamMessage =
+			error?.response?.data?.error ||
+			error?.response?.data?.message ||
+			error?.message ||
+			"ton_rpc_error";
+		const rpcError = new Error(upstreamMessage);
+		rpcError.status = error?.response?.status === 429 ? 429 : 502;
+		rpcError.code = error?.code || "TON_RPC_ERROR";
+		throw rpcError;
+	}
 	if (data.error) {
 		const err = new Error(data.error.message || "ton_rpc_error");
 		err.status = 502;

--- a/Repositories/TON/modules/ton-transfer.module.js
+++ b/Repositories/TON/modules/ton-transfer.module.js
@@ -1,7 +1,15 @@
 const bip39 = require("bip39");
 const { derivePath } = require("ed25519-hd-key");
 const { keyPairFromSeed } = require("@ton/crypto");
-const { WalletContractV5R1, internal, Address, toNano, beginCell } = require("@ton/ton");
+const {
+	WalletContractV5R1,
+	internal,
+	external,
+	storeMessage,
+	Address,
+	toNano,
+	beginCell,
+} = require("@ton/ton");
 const { tonCenterPost } = require("./ton-api.client");
 const { resolveJettonWalletAddress } = require("./ton-jetton.util");
 
@@ -11,9 +19,18 @@ const deriveKeyPairFromMnemonic = async (mnemonic) => {
 	return keyPairFromSeed(derived.slice(0, 32));
 };
 
-const getSeqno = async (address) => {
-	const info = await tonCenterPost("getWalletInformation", { address });
-	return Number(info?.seqno ?? 0);
+const getWalletInformation = (address) => tonCenterPost("getWalletInformation", { address });
+
+const getSeqno = async (address) => Number((await getWalletInformation(address))?.seqno ?? 0);
+
+const buildExternalTransferBoc = (wallet, transfer, accountState) => {
+	const message = external({
+		to: wallet.address,
+		init: accountState === "active" ? undefined : wallet.init,
+		body: transfer,
+	});
+
+	return beginCell().store(storeMessage(message)).endCell().toBoc().toString("base64");
 };
 
 /**
@@ -23,7 +40,8 @@ const getSeqno = async (address) => {
 const sendNativeTransfer = async ({ mnemonic, toAddress, amountTon, comment }) => {
 	const keyPair = await deriveKeyPairFromMnemonic(mnemonic);
 	const wallet = WalletContractV5R1.create({ workchain: 0, publicKey: keyPair.publicKey });
-	const seqno = await getSeqno(wallet.address.toString());
+	const walletInformation = await getWalletInformation(wallet.address.toString());
+	const seqno = Number(walletInformation?.seqno ?? 0);
 
 	const messages = [
 		internal({
@@ -40,7 +58,7 @@ const sendNativeTransfer = async ({ mnemonic, toAddress, amountTon, comment }) =
 		messages,
 	});
 
-	const boc = transfer.toBoc().toString("base64");
+	const boc = buildExternalTransferBoc(wallet, transfer, walletInformation?.account_state);
 	const result = await tonCenterPost("sendBoc", { boc });
 	return {
 		success: true,
@@ -56,7 +74,8 @@ const sendNativeTransfer = async ({ mnemonic, toAddress, amountTon, comment }) =
 const sendJettonTransfer = async ({ mnemonic, toAddress, jettonMaster, amount, decimals = 6 }) => {
 	const keyPair = await deriveKeyPairFromMnemonic(mnemonic);
 	const wallet = WalletContractV5R1.create({ workchain: 0, publicKey: keyPair.publicKey });
-	const seqno = await getSeqno(wallet.address.toString());
+	const walletInformation = await getWalletInformation(wallet.address.toString());
+	const seqno = Number(walletInformation?.seqno ?? 0);
 	const fromFriendly = wallet.address.toString({ bounceable: true, urlSafe: true });
 
 	const senderJettonWallet = await resolveJettonWalletAddress(fromFriendly, jettonMaster);
@@ -91,7 +110,7 @@ const sendJettonTransfer = async ({ mnemonic, toAddress, jettonMaster, amount, d
 		messages,
 	});
 
-	const boc = transfer.toBoc().toString("base64");
+	const boc = buildExternalTransferBoc(wallet, transfer, walletInformation?.account_state);
 	const result = await tonCenterPost("sendBoc", { boc });
 	return {
 		success: true,
@@ -106,5 +125,6 @@ module.exports = {
 	sendNativeTransfer,
 	sendJettonTransfer,
 	getSeqno,
+	buildExternalTransferBoc,
 	deriveKeyPairFromMnemonic,
 };

--- a/tests/unit/ton-transfer.test.js
+++ b/tests/unit/ton-transfer.test.js
@@ -1,0 +1,47 @@
+const { Cell, WalletContractV5R1, internal, loadMessage, toNano } = require("@ton/ton");
+const {
+	buildExternalTransferBoc,
+	deriveKeyPairFromMnemonic,
+} = require("../../Repositories/TON/modules/ton-transfer.module");
+
+describe("TON transfer message", () => {
+	it("wraps the signed wallet request in an external message for Toncenter", async () => {
+		const keyPair = await deriveKeyPairFromMnemonic(
+			"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+		);
+		const wallet = WalletContractV5R1.create({ workchain: 0, publicKey: keyPair.publicKey });
+		const transfer = wallet.createTransfer({
+			seqno: 0,
+			secretKey: keyPair.secretKey,
+			messages: [
+				internal({
+					to: wallet.address,
+					value: toNano("0.01"),
+					bounce: false,
+				}),
+			],
+		});
+
+		const boc = buildExternalTransferBoc(wallet, transfer, "active");
+		const message = loadMessage(Cell.fromBoc(Buffer.from(boc, "base64"))[0].beginParse());
+
+		expect(message.info.type).toBe("external-in");
+		expect(message.info.dest.equals(wallet.address)).toBe(true);
+		expect(message.body.equals(transfer)).toBe(true);
+		expect(message.init).toBeNull();
+	});
+
+	it("includes the wallet state init when the account is not active", async () => {
+		const keyPair = await deriveKeyPairFromMnemonic(
+			"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+		);
+		const wallet = WalletContractV5R1.create({ workchain: 0, publicKey: keyPair.publicKey });
+		const transfer = wallet.createTransfer({ seqno: 0, secretKey: keyPair.secretKey, messages: [] });
+
+		const boc = buildExternalTransferBoc(wallet, transfer, "uninitialized");
+		const message = loadMessage(Cell.fromBoc(Buffer.from(boc, "base64"))[0].beginParse());
+
+		expect(message.init.code.equals(wallet.init.code)).toBe(true);
+		expect(message.init.data.equals(wallet.init.data)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Qué corrige
- Envuelve la solicitud firmada V5R1 dentro del mensaje externo que Toncenter espera.
- Incluye el estado inicial cuando la cuenta TON todavía no está activa.
- Conserva el detalle devuelto por Toncenter para que Android pueda explicar el motivo del rechazo.

## Verificación
- 7 pruebas unitarias de TON aprobadas.
- Prueba directa con una cuenta sin saldo: Toncenter ya procesa el mensaje y devuelve el motivo real de fondos insuficientes, en lugar de `Failed to unpack Message`.

Relacionado con Open-Verifik/zelf-android-online#447.